### PR TITLE
Fix the icon in the scheduler's tooltip

### DIFF
--- a/src/starview.cc
+++ b/src/starview.cc
@@ -486,7 +486,7 @@ bool StarView::event ( QEvent* e )
         } else {
             QToolTip::showText(gp+QPoint(10,10),
                            "<p><table><tr><td>"
-                           "<img align=\"right\" source=\"icons:computer.png\"><br><b>" + tr("Scheduler") + "</b><br/>"
+                           "<img align=\"right\" source=\":/images/icemonnode.png\"><br><b>" + tr("Scheduler") + "</b><br/>"
                            "<table>" +
                            "<tr><td>" + tr("Host: %1").arg(hostInfoManager()->schedulerName()) + "</td></tr>" +
                            "<tr><td>" + tr("Network name: %1").arg(hostInfoManager()->networkName()) + "</td></tr>" +


### PR DESCRIPTION
Use the existing icon the resources for the icon of the scheduler in the scheduler's tooltip of the star view.
