### PR TITLE
Improve how docbook2man is searched for

### DIFF
--- a/cmake/modules/FindDocbook2X.cmake
+++ b/cmake/modules/FindDocbook2X.cmake
@@ -38,8 +38,9 @@ macro(_check_docbook2x_executable)
             OUTPUT_VARIABLE _output
             ERROR_QUIET
         )
-        if("${_output}" MATCHES "docbook2[xX]")
+        if("${_output}" MATCHES "docbook2X ([0-9]+\\.[0-9]+\\.[0-9]+)")
             set(DOCBOOK_TO_MAN_EXECUTABLE ${_docbook_to_man_executable})
+            set(Docbook2X_VERSION ${CMAKE_MATCH_1})
         else()
             unset(DOCBOOK_TO_MAN_EXECUTABLE)
             unset(DOCBOOK_TO_MAN_EXECUTABLE CACHE)
@@ -66,6 +67,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Docbook2X
     FOUND_VAR Docbook2X_FOUND
     REQUIRED_VARS DOCBOOK_TO_MAN_EXECUTABLE
+    VERSION_VAR Docbook2X_VERSION
 )
 
 if (Docbook2X_FOUND)


### PR DESCRIPTION
On ArchLinux, the docbook2X package installs docbook2man. The only way
to force this was to set -D_docbook_to_man_executable on the command
line, which is setting an internal variable.

The new approach is to only pass DOCBOOK_TO_MAN_EXECUTABLE to
find_program (which allows it to be overridden with
-DDOCBOOK_TO_MAN_EXECUTABLE), or to check for each executable name in
turn, using the first one that comes from Docbook2X.

This also makes FindDocbook2X use find_package_handle_standard_args, for
consistent messages etc.

A second commit checks for the version string in the --version output, for ease of later adding a version requirement.

Arguably, the executable variable should really be named something like Docbook2X_MAN_EXECUTABLE (ie: prefix with the package name), but that isn't addressed here.