### PR TITLE
Fix filtering in detailed host view

### DIFF
--- a/src/models/joblistmodel.cc
+++ b/src/models/joblistmodel.cc
@@ -82,6 +82,8 @@ JobListModel::JobListModel(QObject *parent)
     , m_numberOfFilePathParts(2)
     , m_expireDuration(-1)
     , m_expireTimer(new QTimer(this))
+    , m_jobType(AllJobs)
+    , m_hostid(0)
 {
     connect(m_expireTimer, SIGNAL(timeout()),
             this, SLOT(slotExpireFinishedJobs()));
@@ -107,6 +109,14 @@ void JobListModel::setMonitor(Monitor *monitor)
     }
 }
 
+void JobListModel::setHostId(unsigned int hostid)
+{
+    if (m_hostid == hostid)
+        return;
+    m_hostid = hostid;
+    clear();
+}
+
 void JobListModel::updateJob(const Job &job)
 {
     const int index = m_jobs.indexOf(job);
@@ -114,6 +124,10 @@ void JobListModel::updateJob(const Job &job)
         m_jobs[index] = job;
         emit dataChanged(indexForJob(job, 0), indexForJob(job, _JobColumnCount - 1));
     } else {
+        if (m_hostid && m_jobType == RemoteJobs && job.server() != m_hostid)
+            return;
+        if (m_hostid && m_jobType == LocalJobs && job.client() != m_hostid)
+            return;
         beginInsertRows(QModelIndex(), m_jobs.size(), m_jobs.size());
         m_jobs << job;
         endInsertRows();

--- a/src/models/joblistmodel.h
+++ b/src/models/joblistmodel.h
@@ -52,6 +52,13 @@ public:
         _JobColumnCount
     };
 
+    enum JobType
+    {
+        AllJobs,
+        LocalJobs,
+        RemoteJobs
+    };
+
     explicit JobListModel(QObject *parent = nullptr);
 
     Monitor *monitor() const;
@@ -73,6 +80,11 @@ public:
 
     Job jobForIndex(const QModelIndex &index) const;
     QModelIndex indexForJob(const Job &job, int column);
+
+    void setHostId(unsigned int hostid);
+    unsigned int hostId() const { return m_hostid; }
+    void setJobType(JobType type) { m_jobType = type; }
+    JobType jobType() const { return m_jobType; }
 
 private Q_SLOTS:
     void slotExpireFinishedJobs();
@@ -122,6 +134,8 @@ private:
     FinishedJobs m_finishedJobs;
 
     QTimer *m_expireTimer;
+    JobType m_jobType;
+    unsigned int m_hostid;
 };
 
 class JobListSortFilterProxyModel
@@ -130,6 +144,7 @@ class JobListSortFilterProxyModel
     Q_OBJECT
 public:
     JobListSortFilterProxyModel(QObject *parent = nullptr);
+
 protected:
     virtual bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 };

--- a/src/views/detailedhostview.cc
+++ b/src/views/detailedhostview.cc
@@ -69,8 +69,8 @@ DetailedHostView::DetailedHostView(QObject *parent)
     mHostListView = new HostListView(hosts);
     mHostListView->setModel(mSortedHostListModel);
     dummy->addWidget(mHostListView);
-    //connect(mHostListView->selectionModel(), SIGNAL(currentRowChanged(QModelIndex,QModelIndex)),
-    //        SLOT(slotNodeActivated()));
+    connect(mHostListView->selectionModel(), SIGNAL(currentRowChanged(QModelIndex,QModelIndex)),
+            SLOT(slotNodeActivated()));
 
     auto locals = new QWidget(viewSplitter);
     dummy = new QVBoxLayout(locals);
@@ -79,6 +79,7 @@ DetailedHostView::DetailedHostView(QObject *parent)
 
     mLocalJobsModel = new JobListModel(this);
     mLocalJobsModel->setExpireDuration(5);
+    mLocalJobsModel->setJobType(JobListModel::LocalJobs);
     mSortedLocalJobsModel = new JobListSortFilterProxyModel(this);
     mSortedLocalJobsModel->setDynamicSortFilter(true);
     mSortedLocalJobsModel->setSourceModel(mLocalJobsModel);
@@ -96,6 +97,7 @@ DetailedHostView::DetailedHostView(QObject *parent)
 
     mRemoteJobsModel = new JobListModel(this);
     mRemoteJobsModel->setExpireDuration(5);
+    mRemoteJobsModel->setJobType(JobListModel::RemoteJobs);
     mSortedRemoteJobsModel = new JobListSortFilterProxyModel(this);
     mSortedRemoteJobsModel->setDynamicSortFilter(true);
     mSortedRemoteJobsModel->setSourceModel(mRemoteJobsModel);
@@ -144,6 +146,15 @@ void DetailedHostView::createKnownHosts()
     foreach(int hostid, hosts.keys()) {
         checkNode(hostid);
     }
+}
+
+void DetailedHostView::slotNodeActivated()
+{
+    const unsigned int hostid = mHostListView->currentIndex().data(HostListModel::HostIdRole).value<unsigned int>();
+    if (!hostid)
+        return;
+    mLocalJobsModel->setHostId(hostid);
+    mRemoteJobsModel->setHostId(hostid);
 }
 
 QWidget *DetailedHostView::widget() const

--- a/src/views/detailedhostview.h
+++ b/src/views/detailedhostview.h
@@ -31,6 +31,7 @@ class JobListView;
 class JobListModel;
 class HostListView;
 class QSortFilterProxyModel;
+class JobListSortFilterProxyModel;
 
 class DetailedHostView
     : public StatusView
@@ -48,6 +49,9 @@ public:
 
     void checkNode(unsigned int hostid) override;
 
+private slots:
+    void slotNodeActivated();
+
 private:
     void createKnownHosts();
 
@@ -59,11 +63,11 @@ private:
 
     JobListModel *mLocalJobsModel;
     JobListView *mLocalJobsView;
-    QSortFilterProxyModel *mSortedLocalJobsModel;
+    JobListSortFilterProxyModel *mSortedLocalJobsModel;
 
     JobListModel *mRemoteJobsModel;
     JobListView *mRemoteJobsView;
-    QSortFilterProxyModel *mSortedRemoteJobsModel;
+    JobListSortFilterProxyModel *mSortedRemoteJobsModel;
 };
 
 #endif


### PR DESCRIPTION
The incoming and outgoing jobs were not filtered by host like
they used to be.