### PR TITLE
Add scheduler host-name option

### DIFF
--- a/doc/man-icemon.1.xml
+++ b/doc/man-icemon.1.xml
@@ -59,6 +59,14 @@ network and monitor its traffic.</para>
 </para></listitem>
 </varlistentry>
 
+
+<varlistentry>
+<term><option>-s</option>, <option>--scheduler</option>
+<parameter>host-name</parameter></term>
+<listitem><para>The hostname of the Icecream scheduler &icemon; should connect to.
+</para></listitem>
+</varlistentry>
+
 </variablelist>
 
 </refsect1>

--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -110,6 +110,7 @@ void IcecreamMonitor::slotCheckScheduler()
         return;
     }
 
+    const string hostname = currentSchedname().isEmpty() ? "" : currentSchedname().data();
     list<string> names;
 
     if (!currentNetname().isEmpty()) {
@@ -127,7 +128,7 @@ void IcecreamMonitor::slotCheckScheduler()
         if (!m_discover
             || m_discover->timed_out()) {
             delete m_discover;
-            m_discover = new DiscoverSched(QBA_toStdString(currentNetname()));
+            m_discover = new DiscoverSched(QBA_toStdString(currentNetname()), 2, hostname);
         }
 
         m_scheduler = m_discover->try_get_scheduler();

--- a/src/main.cc
+++ b/src/main.cc
@@ -43,6 +43,10 @@ int main(int argc, char **argv)
         QCoreApplication::translate("main", "Icecream network name."),
         QCoreApplication::translate("main", "name", "network name"));
     parser.addOption(netnameOption);
+    QCommandLineOption schednameOption(QStringList() << QStringLiteral("s") << QStringLiteral("scheduler"),
+        QCoreApplication::translate("main", "Icecream scheduler hostname"),
+        QCoreApplication::translate("main", "hostname", "scheduler hostname"));
+    parser.addOption(schednameOption);
     QCommandLineOption testmodeOption(QStringLiteral("testmode"),
         QCoreApplication::translate("main", "Testing mode."));
     parser.addOption(testmodeOption);
@@ -50,10 +54,14 @@ int main(int argc, char **argv)
     parser.process(app);
 
     const QByteArray netName = parser.value(netnameOption).toLatin1();
+    const QByteArray schedName = parser.value(schednameOption).toLatin1();
 
     MainWindow mainWindow;
     if (!netName.isEmpty()) {
         mainWindow.setCurrentNet(netName);
+    }
+    if (!schedName.isEmpty()) {
+        mainWindow.setCurrentSched(schedName);
     }
     if (parser.isSet(testmodeOption)) {
         mainWindow.setTestModeEnabled(true);
@@ -62,4 +70,3 @@ int main(int argc, char **argv)
 
     return app.exec();
 }
-

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -354,9 +354,14 @@ void MainWindow::updateJobStats()
     m_jobStatsWidget->setVisible(true);
 }
 
-void MainWindow::setCurrentNet(const QByteArray &netName)
+void MainWindow::setCurrentNet(const QByteArray &netname)
 {
-    m_monitor->setCurrentNetname(netName);
+    m_monitor->setCurrentNetname(netname);
+}
+
+void MainWindow::setCurrentSched(const QByteArray &schedname)
+{
+    m_monitor->setCurrentSchedname(schedname);
 }
 
 void MainWindow::handleViewModeActionTriggered(QAction *action)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -46,6 +46,7 @@ public:
     virtual ~MainWindow();
 
     void setCurrentNet(const QByteArray &netname);
+    void setCurrentSched(const QByteArray &schedname);
 
     Monitor *monitor() const;
     StatusView *view() const;

--- a/src/monitor.cc
+++ b/src/monitor.cc
@@ -39,6 +39,16 @@ void Monitor::setCurrentNetname(const QByteArray &netname)
     m_currentNetname = netname;
 }
 
+QByteArray Monitor::currentSchedname() const
+{
+    return m_currentSchedname;
+}
+
+void Monitor::setCurrentSchedname(const QByteArray &schedname)
+{
+    m_currentSchedname = schedname;
+}
+
 Monitor::SchedulerState Monitor::schedulerState() const
 {
     return m_schedulerState;

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -51,6 +51,9 @@ public
     QByteArray currentNetname() const;
     void setCurrentNetname(const QByteArray &);
 
+    QByteArray currentSchedname() const;
+    void setCurrentSchedname(const QByteArray &);
+
     SchedulerState schedulerState() const;
 
     virtual QList<Job> jobHistory() const;
@@ -70,6 +73,7 @@ Q_SIGNALS:
 private:
     HostInfoManager *m_hostInfoManager;
     QByteArray m_currentNetname;
+    QByteArray m_currentSchedname;
     SchedulerState m_schedulerState;
 };
 


### PR DESCRIPTION
Add option to connect icemon to scheduler by host-name.
This is helpful when your scheduler could not be identified by net-name and avoid $USE_SCHEDULER usage.
Actually, the option has higher priority than $USE_SCHEDULER.
