### PR TITLE
FindDocbook2X.cmake: Add Fedora's executable name

### DIFF
--- a/cmake/modules/FindDocbook2X.cmake
+++ b/cmake/modules/FindDocbook2X.cmake
@@ -51,7 +51,7 @@ endmacro()
 if (DOCBOOK_TO_MAN_EXECUTABLE)
     _check_docbook2x_executable()
 else()
-    foreach(test_exec docbook2x-man docbook-to-man docbook2man)
+    foreach(test_exec docbook2x-man docbook-to-man db2x_docbook2man docbook2man)
         find_program(DOCBOOK_TO_MAN_EXECUTABLE
             NAMES ${test_exec}
         )


### PR DESCRIPTION
I attempted to build this for Fedora, however it seems it couldn't build the man page. 
This PR fixes this by adding db2x_docbook2man to the list of names tried.
