### PR TITLE
SummaryView: Remove hardcoded background color

### DIFF
--- a/src/views/summaryview.cc
+++ b/src/views/summaryview.cc
@@ -274,7 +274,6 @@ SummaryView::SummaryView(QObject *parent)
     , m_widget(new SummaryViewScrollArea)
 {
     m_base = new QWidget;
-    m_base->setStyleSheet(QStringLiteral("QWidget { background-color: 'white'; }"));
     m_widget->setWidget(m_base);
 
     m_layout = new QGridLayout(m_base);


### PR DESCRIPTION
Otherwise we will get white text on a white background when a dark theme
is used, such as KDE's "Breeze Dark".