### PR TITLE
adjust for icecream change that has broken scheduler discovery

### DIFF
--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -126,12 +126,10 @@ void IcecreamMonitor::slotCheckScheduler()
          ++it) {
         setCurrentNetname(QBA_fromStdString(*it));
         if (!m_discover
-            || m_discover->timed_out()) {
+            || ((m_scheduler = m_discover->try_get_scheduler()) == NULL && m_discover->timed_out())) {
             delete m_discover;
             m_discover = new DiscoverSched(QBA_toStdString(currentNetname()), 2, hostname);
         }
-
-        m_scheduler = m_discover->try_get_scheduler();
 
         if (m_scheduler) {
             hostInfoManager()->setSchedulerName(QString::fromLatin1(m_discover->schedulerName().data()));


### PR DESCRIPTION
47ba035d4dc024d460758c3cf99df1a1a2908db2 in icecream has changed
the discovery to always timeout and only then return a scheduler.
So first checking for timeout and only then trying to get a scheduler
now never provides the scheduler. Change the code the same way
iceccd has been changed in that commit.