### PR TITLE
Workaround node data loss when switching between views, and incorrect active jobs counter.

### DIFF
--- a/src/hostinfo.cc
+++ b/src/hostinfo.cc
@@ -188,6 +188,12 @@ HostInfo *HostInfoManager::checkNode(unsigned int hostid,
     }
 
     hostInfo->updateFromStatsMap(stats);
+    if (hostInfo->isOffline()) {
+        mHostMap.remove(hostid);
+        delete hostInfo;
+        hostInfo = nullptr;
+    }
+
     emit hostMapChanged();
 
     return hostInfo;

--- a/src/hostinfo.h
+++ b/src/hostinfo.h
@@ -47,6 +47,9 @@ public:
 
     void setMaxJobs(unsigned int jobs) { mMaxJobs = jobs; }
     unsigned int maxJobs() const { return mMaxJobs; }
+    void incJobs() { mNumJobs++; }
+    void decJobs() { if (mNumJobs) mNumJobs--; }
+    unsigned int numJobs() const { return mNumJobs; }
 
     void setOffline(bool offline) { mOffline = offline; }
     bool isOffline() const { return mOffline; }
@@ -89,6 +92,7 @@ private:
     QString mIp;
 
     unsigned int mMaxJobs = 0;
+    unsigned int mNumJobs = 0;
     bool mOffline = false;
     bool mNoRemote = true;
 

--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -308,6 +308,10 @@ void IcecreamMonitor::handle_job_begin(Msg *_m)
         return;
     }
 
+    HostInfo *hostInfo = hostInfoManager()->find(m->hostid);
+    if (hostInfo)
+        hostInfo->incJobs();
+
     (*it).server = m->hostid;
     (*it).startTime = m->stime;
     (*it).state = Job::Compiling;
@@ -327,6 +331,10 @@ void IcecreamMonitor::handle_job_done(Msg *_m)
         // we started in between
         return;
     }
+
+    HostInfo *hostInfo = hostInfoManager()->find((*it).server);
+    if (hostInfo)
+        hostInfo->decJobs();
 
     (*it).exitcode = m->exitcode;
     if (m->exitcode) {

--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -288,7 +288,7 @@ void IcecreamMonitor::handle_stats(Msg *_m)
 
     HostInfo *hostInfo = hostInfoManager()->checkNode(m->hostid, stats);
 
-    if (hostInfo->isOffline()) {
+    if (!hostInfo) {
         emit nodeRemoved(m->hostid);
     } else {
         emit nodeUpdated(m->hostid);

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -317,7 +317,7 @@ void MainWindow::updateJobStats()
     }
     for (JobList::const_iterator i = m_activeJobs.constBegin(); i != m_activeJobs.constEnd(); ++i) {
         const HostInfo *server = hostMap[i.value().server != 0 ? i.value().server : i.value().client];
-        if (!server->isOffline() && !server->noRemote()) {
+        if (server && !server->isOffline() && !server->noRemote()) {
             ++perPlatformStats[server->platform()].jobs;
         }
     }

--- a/src/views/flowtableview.cc
+++ b/src/views/flowtableview.cc
@@ -88,6 +88,8 @@ FlowTableView::FlowTableView(QObject *parent)
 
     m_updateTimer->setInterval(50);
     m_updateTimer->start();
+
+    createKnownHosts();
 }
 
 void FlowTableView::update(const Job &job)
@@ -154,6 +156,30 @@ QString FlowTableView::hostInfoText(HostInfo *hostInfo, int runningProcesses) {
     }
 }
 
+void FlowTableView::createKnownHosts()
+{
+    if (!hostInfoManager()) {
+        return;
+    }
+
+    m_widget->setRowCount(0);
+    m_idToRowMap.clear();
+
+    const HostInfoManager::HostMap hosts(hostInfoManager()->hostMap());
+
+    foreach(int hostid, hosts.keys()) {
+        checkNode(hostid);
+    }
+}
+
+void FlowTableView::setMonitor(Monitor *monitor)
+{
+    StatusView::setMonitor(monitor);
+
+    if (monitor)
+	    createKnownHosts();
+}
+
 void FlowTableView::checkNode(unsigned int hostId)
 {
     if (m_idToRowMap.contains(hostId)) {
@@ -191,6 +217,7 @@ void FlowTableView::checkNode(unsigned int hostId)
 
 void FlowTableView::removeNode(unsigned int hostId)
 {
-    m_widget->removeRow(m_idToRowMap.value(hostId));
-    m_idToRowMap.remove(hostId);
+    Q_UNUSED(hostId);
+
+    createKnownHosts();
 }

--- a/src/views/flowtableview.cc
+++ b/src/views/flowtableview.cc
@@ -128,19 +128,12 @@ void FlowTableView::update(const Job &job)
 
     // update the host column for the server requesting the job
     QTableWidgetItem *hostNameItem = m_widget->item(serverRow, 0);
-    int usageCount = hostNameItem->data(Qt::UserRole).toInt();
-    if (job.state == Job::LocalOnly || job.state == Job::Compiling) {
-        ++usageCount;
-    } else if (job.state == Job::Finished || job.state == Job::Failed) {
-        --usageCount;
-    }
-
-    hostNameItem->setData(Qt::UserRole, usageCount);
+    HostInfo *hostInfo = hostInfoManager()->find(serverId);
 
     QFont f = m_widget->font();
-    f.setBold(usageCount > 0);
+    f.setBold(hostInfo->numJobs() > 0);
     hostNameItem->setFont(f);
-    hostNameItem->setText(hostInfoText(hostInfoManager()->find(serverId), usageCount));
+    hostNameItem->setText(hostInfoText(hostInfo));
 }
 
 QWidget *FlowTableView::widget() const
@@ -148,11 +141,11 @@ QWidget *FlowTableView::widget() const
     return m_widget.data();
 }
 
-QString FlowTableView::hostInfoText(HostInfo *hostInfo, int runningProcesses) {
-    if (hostInfo->serverSpeed() == 0) { // host disabled
+QString FlowTableView::hostInfoText(HostInfo *hostInfo) {
+    if ((hostInfo->serverSpeed() == 0) && (hostInfo->numJobs() == 0)) { // host disabled
         return tr("%1 (Disabled)").arg(hostInfo->name());
     } else {
-        return tr("%1 (%2/%3)").arg(hostInfo->name()).arg(runningProcesses).arg(hostInfo->maxJobs());
+        return tr("%1 (%2/%3)").arg(hostInfo->name()).arg(hostInfo->numJobs()).arg(hostInfo->maxJobs());
     }
 }
 
@@ -191,8 +184,6 @@ void FlowTableView::checkNode(unsigned int hostId)
     widgetItem->setIcon(QIcon(QStringLiteral(":/images/icemonnode.png")));
     widgetItem->setToolTip(hostInfo->toolTip());
     widgetItem->setBackgroundColor(hostInfo->color());
-    // usage count
-    widgetItem->setData(Qt::UserRole, 0);
     widgetItem->setFlags(Qt::ItemIsEnabled);
     int insertRow = m_widget->rowCount();
     m_widget->setRowCount(insertRow + 1);

--- a/src/views/flowtableview.h
+++ b/src/views/flowtableview.h
@@ -62,6 +62,8 @@ public:
 
     QWidget *widget() const override;
 
+    void setMonitor(Monitor *monitor) override;
+
     void update(const Job &job) override;
     void checkNode(unsigned int hostid) override;
     void removeNode(unsigned int hostid) override;
@@ -79,6 +81,8 @@ private:
     QString hostInfoText(HostInfo *hostInfo, int runningProcesses = 0);
     HostIdRowMap m_idToRowMap;
     QTimer *m_updateTimer;
+
+    void createKnownHosts();
 };
 
 #endif // FLOWTABLEVIEW_H

--- a/src/views/flowtableview.h
+++ b/src/views/flowtableview.h
@@ -78,7 +78,7 @@ public:
 
 private:
     QScopedPointer<QTableWidget> m_widget;
-    QString hostInfoText(HostInfo *hostInfo, int runningProcesses = 0);
+    QString hostInfoText(HostInfo *hostInfo);
     HostIdRowMap m_idToRowMap;
     QTimer *m_updateTimer;
 

--- a/src/views/ganttstatusview.cc
+++ b/src/views/ganttstatusview.cc
@@ -381,6 +381,11 @@ QWidget *GanttStatusView::widget() const
     return m_widget.data();
 }
 
+void GanttStatusView::removeNode(unsigned int hostid)
+{
+	unregisterNode(hostid);
+}
+
 void GanttStatusView::checkNode(unsigned int hostid)
 {
     if (!mRunning) {

--- a/src/views/ganttstatusview.h
+++ b/src/views/ganttstatusview.h
@@ -129,6 +129,7 @@ public:
 
     QString id() const override { return QStringLiteral("gantt"); }
 
+    void removeNode(unsigned int hostid) override;
     void checkNode(unsigned int hostid) override;
 
     void start() override;

--- a/src/views/starview.cc
+++ b/src/views/starview.cc
@@ -478,23 +478,10 @@ void StarView::removeNode(unsigned int hostid)
 
     HostItem *hostItem = findHostItem(hostid);
 
-    if (hostItem && hostItem->hostInfo()->isOffline()) {
-        removeItem(hostItem);
-    }
-}
+    if (!hostItem)
+	    return;
 
-void StarView::forceRemoveNode(unsigned int hostid)
-{
-    HostItem *hostItem = findHostItem(hostid);
-
-    if (hostItem) {
-        removeItem(hostItem);
-    }
-}
-
-void StarView::removeItem(HostItem *hostItem)
-{
-    m_hostItems.remove(hostItem->hostInfo()->id());
+    m_hostItems.remove(hostid);
 
     QList<unsigned int> obsoleteJobs;
 
@@ -621,7 +608,7 @@ void StarView::slotConfigChanged()
         if (filterArch(*it)) {
             checkNode(it.key());
         } else {
-            forceRemoveNode(it.key());
+            removeNode(it.key());
         }
     }
 

--- a/src/views/starview.h
+++ b/src/views/starview.h
@@ -210,9 +210,6 @@ public:
      */
     bool filterArch(HostInfo *);
 
-    void removeItem(HostItem *);
-    void forceRemoveNode(unsigned int hostid);
-
 protected slots:
     void slotConfigChanged();
 

--- a/src/views/summaryview.h
+++ b/src/views/summaryview.h
@@ -85,7 +85,10 @@ public:
     ~SummaryView() override;
 
     QWidget *widget() const override;
+
+    void setMonitor(Monitor *monitor) override;
     void update(const Job &job) override;
+    void removeNode(unsigned int hostid) override;
     void checkNode(unsigned int hostid) override;
     QString id() const override { return QStringLiteral("summary"); }
 
@@ -95,6 +98,8 @@ private:
     QMap<unsigned int, SummaryViewItem *> m_items;
     QGridLayout *m_layout;
     QWidget *m_base;
+
+    void createKnownHosts();
 };
 
 #endif


### PR DESCRIPTION
Please, take a look at this attempt to workaround node data loss when switching between views and re- starting iceccd daemons while icemon is running.