### PR TITLE
Use QDialogButtonBox for dialogs

### DIFF
--- a/src/views/ganttstatusview.cc
+++ b/src/views/ganttstatusview.cc
@@ -40,6 +40,7 @@
 #include <QResizeEvent>
 #include <QPaintEvent>
 #include <QScrollBar>
+#include <QDialogButtonBox>
 
 GanttConfigDialog::GanttConfigDialog(QWidget *parent)
     : QDialog(parent)
@@ -62,9 +63,9 @@ GanttConfigDialog::GanttConfigDialog(QWidget *parent)
 
     buttonLayout->addStretch(1);
 
-    QPushButton *button = new QPushButton(tr("&Close"), this);
-    buttonLayout->addWidget(button);
-    connect(button, SIGNAL(clicked()), SLOT(hide()));
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    buttonLayout->addWidget(buttonBox);
+    connect(buttonBox, SIGNAL(rejected()), SLOT(hide()));
 
     setWindowTitle(tr("Configure Gantt View"));
     // apply some minimum size

--- a/src/views/starview.cc
+++ b/src/views/starview.cc
@@ -40,6 +40,7 @@
 #include <QResizeEvent>
 #include <QGraphicsScene>
 #include <QGraphicsView>
+#include <QDialogButtonBox>
 
 #include <math.h>
 
@@ -85,14 +86,14 @@ StarViewConfigDialog::StarViewConfigDialog(QWidget *parent)
     hline->setFrameShape(QFrame::HLine);
     hline->setFrameShadow(QFrame::Sunken);
     topLayout->addWidget(hline);
-    QPushButton *closeButton = new QPushButton(tr("&Close"));
-    closeButton->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
-    topLayout->addWidget(closeButton, 0, Qt::AlignRight);
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    topLayout->addWidget(buttonBox);
 
     connect(mSuppressDomainName, SIGNAL(toggled(bool)),
             SLOT(slotSuppressDomainName(bool)));
 
-    connect(closeButton, SIGNAL(clicked()), SLOT(accept()));
+    connect(buttonBox, SIGNAL(rejected()), SLOT(accept()));
 }
 
 void StarViewConfigDialog::slotNodesPerRingChanged(int nodes)


### PR DESCRIPTION
Make use of `QDialogButtonBox` in dialogs, instead of creating Close buttons manually.  This makes their look a bit more native.