### PR TITLE
Explicitly disable socket notifiers before calling deleteLater

### DIFF
--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -96,6 +96,7 @@ void IcecreamMonitor::checkScheduler(bool deleteit)
 void IcecreamMonitor::registerNotify(int fd, QSocketNotifier::Type type, const char *slot)
 {
     if (m_fd_notify) {
+        m_fd_notify->setEnabled(false);
         m_fd_notify->disconnect(this);
         m_fd_notify->deleteLater();
     }


### PR DESCRIPTION
This fixes the IcecreamMonitor to work on macOS with Qt 5.12.

Because registerNotify() gets called a second time with the same
fd number, and tries to create a new QSocketNotifier before
deleting / disabling the existing notifier, some macOS specific
socket internals gets messed up, and no notifications go through.

This can be confirmed by using a debug build of Qt, which
asserts in QCFSocketNotifier::registerSocketNotifier because there
is an already existing notifier on the given file descriptor.