### PR TITLE
make travis build using git icecream instead of ubuntu package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,32 @@ compiler:
 - gcc
 - clang
 
-before_install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq cmake qtbase5-dev libicecc-dev extra-cmake-modules
-
 before_script:
+- |
+    git clone --depth=50 --branch=master https://github.com/icecc/icecream.git icecream
+    pushd icecream
+    autoreconf -fiv
+    ./configure --prefix=$(pwd)
+    make install -C services -s -j $(getconf _NPROCESSORS_ONLN)
+    popd
+
 - cmake --version
 - qtchooser -run-tool=qmake -qt=qt5 --version
 
 - mkdir build
 - cd build
-- cmake ..
+- PKG_CONFIG_PATH=../icecream/lib/pkgconfig cmake ..
 
 script: make
+
+addons:
+  apt:
+    packages:
+    - cmake
+    - qtbase5-dev
+    - extra-cmake-modules
+    # for icecream
+    - libcap-ng-dev
+    - liblzo2-dev
+    - libzstd1-dev
+    - libarchive-dev


### PR DESCRIPTION
It makes sense in general, and #51 actually requires this.