### PR TITLE
display also node protocol version and features in detailed host view

### DIFF
--- a/src/fakemonitor.cc
+++ b/src/fakemonitor.cc
@@ -29,6 +29,8 @@
 #include <QTime>
 #include <QTimer>
 
+#include <icecc/comm.h>
+
 namespace {
 // counter variable
 int JOB_ID = 0;
@@ -83,6 +85,8 @@ void FakeMonitor::createHostInfo(HostId id)
     info.setOffline(false);
     info.setNoRemote(false);
     info.setPlatform(randomPlatform());
+    info.setProtocol(PROTOCOL_VERSION);
+    info.setFeatures(id % 2 == 0 ? QStringLiteral("env_xz") : QStringLiteral("env_zstd"));
     info.setServerLoad(1.0);
     info.setServerSpeed(10);
     hostInfoManager()->checkNode(info);

--- a/src/hostinfo.cc
+++ b/src/hostinfo.cc
@@ -112,6 +112,8 @@ void HostInfo::updateFromStatsMap(const StatsMap &stats)
         mColor = createColor(mName);
         mIp = stats[QStringLiteral("IP")];
         mPlatform = stats[QStringLiteral("Platform")];
+        mProtocol = stats[QStringLiteral("Version")].toInt();
+        mFeatures = stats[QStringLiteral("Features")];
     }
 
     mNoRemote = (stats[QStringLiteral("NoRemote")].compare(QLatin1String("true"), Qt::CaseInsensitive) == 0);

--- a/src/hostinfo.h
+++ b/src/hostinfo.h
@@ -69,6 +69,12 @@ public:
     void setServerLoad(unsigned int load) { mServerLoad = load; }
     unsigned int serverLoad() const { return mServerLoad; }
 
+    void setProtocol(unsigned int protocol) { mProtocol = protocol; }
+    int protocol() const { return mProtocol; }
+
+    void setFeatures(const QString& features) { mFeatures = features; }
+    QString features() const { return mFeatures; }
+
     QString toolTip() const;
 
     bool operator==(const HostInfo &rhs) const { return mId == rhs.mId; }
@@ -95,9 +101,10 @@ private:
     unsigned int mNumJobs = 0;
     bool mOffline = false;
     bool mNoRemote = true;
+    int mProtocol = 0;
+    QString mFeatures;
 
     float mServerSpeed = 0.0;
-
     unsigned int mServerLoad = 0;
 
     static QVector<QColor> mColorTable;

--- a/src/models/hostlistmodel.cc
+++ b/src/models/hostlistmodel.cc
@@ -76,6 +76,10 @@ QVariant HostListModel::headerData(int section, Qt::Orientation orientation, int
             return tr("IP");
         case ColumnPlatform:
             return tr("Platform");
+        case ColumnProtocol:
+            return tr("Protocol");
+        case ColumnFeatures:
+            return tr("Features");
         case ColumnMaxJobs:
             return tr("Max Jobs");
         case ColumnSpeed:
@@ -114,6 +118,10 @@ QVariant HostListModel::data(const QModelIndex &index, int role) const
             return info.ip();
         case ColumnPlatform:
             return info.platform();
+        case ColumnProtocol:
+            return info.protocol() > 0 ? QString::number(info.protocol()) : QStringLiteral("?");
+        case ColumnFeatures:
+            return info.features().isEmpty() ? QStringLiteral( " - " ) : info.features();
         case ColumnMaxJobs:
             return info.maxJobs();
         case ColumnSpeed:
@@ -129,6 +137,8 @@ QVariant HostListModel::data(const QModelIndex &index, int role) const
             return Qt::AlignRight;
         case ColumnNoRemote:
             return Qt::AlignCenter;
+        case ColumnProtocol:
+            return Qt::AlignRight;
         case ColumnMaxJobs:
             return Qt::AlignRight;
         case ColumnSpeed:

--- a/src/models/hostlistmodel.h
+++ b/src/models/hostlistmodel.h
@@ -43,6 +43,8 @@ public:
         ColumnColor,
         ColumnIP,
         ColumnPlatform,
+        ColumnProtocol,
+        ColumnFeatures,
         ColumnMaxJobs,
         ColumnSpeed,
         ColumnLoad,


### PR DESCRIPTION
This should be useful when checking if there are old nodes or ones
that do not support e.g. xz tarball compression. The telnet interface
provides this info, but icemon is more known and easier to use.