### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ compiler:
 - gcc
 - clang
 
+arch:
+  - amd64
+  - ppc64le
+
 before_script:
 - |
     git clone --depth=50 --branch=master https://github.com/icecc/icecream.git icecream


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/icemon/builds/191441135 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!