### PR TITLE
Harden star view visualization

### DIFF
--- a/src/icecreammonitor.cc
+++ b/src/icecreammonitor.cc
@@ -264,11 +264,20 @@ void IcecreamMonitor::handle_local_done(Msg *_m)
     (*it).state = Job::Finished;
     emit jobUpdated(*it);
 
-    if (m_rememberedJobs.size() > 3000) {   // now remove 1000
+    if (m_rememberedJobs.size() > 3000) {   // now remove 1000 completed jobs
         uint count = 1000;
-
-        while (--count)
-            m_rememberedJobs.erase(m_rememberedJobs.begin());
+        JobList::iterator it = m_rememberedJobs.begin();
+        while (count > 0 && it != m_rememberedJobs.end()) {
+            if (it.value().isDone()) {
+                JobList::iterator next = it;
+                ++next;
+                m_rememberedJobs.erase(it);
+                it = next;
+                --count;
+            } else {
+                ++it;
+            }
+        }
     }
 }
 

--- a/src/views/starview.cc
+++ b/src/views/starview.cc
@@ -389,37 +389,46 @@ void StarView::update(const Job &job)
     }
 
     unsigned int hostid = processor(job);
-    if (!hostid) {
-        return;
-    }
-
-    HostItem *hostItem = findHostItem(hostid);
-    if (!hostItem) {
-        return;
-    }
-
-    hostItem->update(job);
+    HostItem *hostItem = hostid ? findHostItem(hostid) : nullptr;
 
     bool finished = job.state == Job::Finished || job.state == Job::Failed;
 
-    QMap<unsigned int, HostItem *>::Iterator it;
-    it = mJobMap.find(job.id);
+    QMap<unsigned int, HostItem *>::Iterator it = mJobMap.find(job.id);
     if (it != mJobMap.end()) {
-        (*it)->update(job);
-        if (finished) {
-            mJobMap.erase(it);
-            unsigned int clientid = job.client;
-            HostItem *clientItem = findHostItem(clientid);
-            if (clientItem) {
-                clientItem->setIsActiveClient(false);
+        HostItem *oldHostItem = *it;
+
+        if (oldHostItem != hostItem) {
+            Job finishedJob = job;
+            finishedJob.state = Job::Finished;
+            oldHostItem->update(finishedJob);
+
+            if (hostItem && !finished) {
+                hostItem->update(job);
+                *it = hostItem;
+            } else {
+                mJobMap.erase(it);
+                unsigned int clientid = job.client;
+                HostItem *clientItem = findHostItem(clientid);
+                if (clientItem) {
+                    clientItem->setIsActiveClient(false);
+                }
+            }
+        } else {
+            hostItem->update(job);
+            if (finished) {
+                mJobMap.erase(it);
+                unsigned int clientid = job.client;
+                HostItem *clientItem = findHostItem(clientid);
+                if (clientItem) {
+                    clientItem->setIsActiveClient(false);
+                }
             }
         }
-        m_widget->drawNodeStatus();
-        return;
-    }
-
-    if (!finished) {
-        mJobMap.insert(job.id, hostItem);
+    } else {
+        if (hostItem && !finished) {
+            hostItem->update(job);
+            mJobMap.insert(job.id, hostItem);
+        }
     }
 
     if (job.state == Job::Compiling) {


### PR DESCRIPTION
When jobs were initially scheduled on one runner and later move to another runner -  such as when a timeout results in a job running on the host requesting the build - the star view could show the ring corresponding to that job forever.  Navigating off of the star view and back to that view would clear the ring (icecc/icemon#34), but it would not decrement the active job count.

Fix was two parts:
* First, when pruning jobs, prune completed jobs to prevent losing references to active jobs
* Second, handle jobs that change hosts explicitly so they can be marked as finished appropriately

Verified by running icemon a full day with the changes.  Previous version would accumulate "zombie" jobs steadily throughout the day.